### PR TITLE
Redesign gameplay UI with segmented inputs and wrong guess tracking

### DIFF
--- a/client/src/components/GameBoard.tsx
+++ b/client/src/components/GameBoard.tsx
@@ -1,52 +1,234 @@
-import React from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { GameState } from "../types";
 
 interface GameBoardProps {
   state: GameState;
   onGuess: (guess: string) => void;
-  guessValue: string;
-  setGuessValue: (v: string) => void;
   error: string;
   celebratory: boolean;
+  myGuessedCount: number;
+  opponentGuessedCount: number;
+  myWrongGuesses: string[];
+  opponentWrongGuesses: string[];
 }
 
-const GameBoard: React.FC<GameBoardProps> = ({ state, onGuess, guessValue, setGuessValue, error, celebratory }) => (
-  <div style={{ padding: 32, maxWidth: 600, margin: "auto", textAlign: "center" }}>
-    <h2>8Words Game</h2>
-    <div style={{ margin: 16 }}>
-      <b>Your words left:</b> {state.myWordsLeft.join(", ")}
+const boxStyle: React.CSSProperties = {
+  width: 48,
+  height: 56,
+  border: "2px solid #444",
+  borderRadius: 8,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontSize: 28,
+  fontWeight: 600,
+  background: "#f8f8f8",
+  color: "#222",
+};
+
+const inputStyle: React.CSSProperties = {
+  ...boxStyle,
+  background: "#fff",
+  textTransform: "uppercase",
+  outline: "none",
+};
+
+const GameBoard: React.FC<GameBoardProps> = ({
+  state,
+  onGuess,
+  error,
+  celebratory,
+  myGuessedCount,
+  opponentGuessedCount,
+  myWrongGuesses,
+  opponentWrongGuesses,
+}) => {
+  const currentWord = useMemo(
+    () => state.opponentWordsLeft.find((entry) => !entry.revealed && entry.word.length > 0),
+    [state.opponentWordsLeft],
+  );
+
+  const firstLetter = currentWord?.word?.[0] ?? "";
+  const missingLettersCount = Math.max((currentWord?.word?.length ?? 0) - 1, 0);
+  const [letters, setLetters] = useState<string[]>(() => Array(missingLettersCount).fill(""));
+  const inputsRef = useRef<(HTMLInputElement | null)[]>([]);
+
+  useEffect(() => {
+    setLetters(Array(missingLettersCount).fill(""));
+    inputsRef.current = [];
+  }, [missingLettersCount, currentWord?.word]);
+
+  useEffect(() => {
+    if (!state.isMyTurn || celebratory || letters.length === 0) return;
+    const firstEmpty = letters.findIndex((letter) => letter === "");
+    const targetIndex = firstEmpty === -1 ? letters.length - 1 : firstEmpty;
+    if (targetIndex >= 0) {
+      const input = inputsRef.current[targetIndex];
+      input?.focus();
+      input?.select();
+    }
+  }, [letters, state.isMyTurn, celebratory]);
+
+  const handleLetterChange = (index: number, value: string) => {
+    const trimmed = value.slice(-1);
+    const sanitized = trimmed.replace(/[^a-zA-Z]/g, "").toUpperCase();
+    setLetters((prev) => {
+      const next = [...prev];
+      next[index] = sanitized;
+      return next;
+    });
+    if (sanitized && index < letters.length - 1) {
+      const nextInput = inputsRef.current[index + 1];
+      nextInput?.focus();
+      nextInput?.select();
+    }
+  };
+
+  const handleKeyDown = (index: number, event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Backspace" && letters[index] === "" && index > 0) {
+      event.preventDefault();
+      const prevInput = inputsRef.current[index - 1];
+      prevInput?.focus();
+      prevInput?.select();
+      return;
+    }
+    if (event.key === "ArrowLeft" && index > 0) {
+      event.preventDefault();
+      inputsRef.current[index - 1]?.focus();
+      inputsRef.current[index - 1]?.select();
+    }
+    if (event.key === "ArrowRight" && index < letters.length - 1) {
+      event.preventDefault();
+      inputsRef.current[index + 1]?.focus();
+      inputsRef.current[index + 1]?.select();
+    }
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!state.isMyTurn || celebratory || !currentWord) return;
+    const guess = `${firstLetter}${letters.join("")}`;
+    if (!guess.trim()) return;
+    onGuess(guess);
+  };
+
+  const canSubmit =
+    state.isMyTurn &&
+    !celebratory &&
+    !!currentWord &&
+    (letters.length === 0 || letters.every((letter) => letter.length === 1));
+
+  const guessableTotal = Math.max(state.opponentWordsLeft.length - 1, 1);
+  const defendTotal = Math.max(state.myWordsLeft.length - 1, 1);
+
+  return (
+    <div style={{ padding: 32, maxWidth: 720, margin: "0 auto", textAlign: "center" }}>
+      <h2 style={{ marginBottom: 24 }}>8Words Game</h2>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          gap: 32,
+          marginBottom: 24,
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ minWidth: 160 }}>
+          <div style={{ fontSize: 14, color: "#555", textTransform: "uppercase", letterSpacing: 1.4 }}>
+            Your correct guesses
+          </div>
+          <div style={{ fontSize: 28, fontWeight: 700, color: "#2f855a" }}>
+            {myGuessedCount}/{guessableTotal}
+          </div>
+        </div>
+        <div style={{ minWidth: 160 }}>
+          <div style={{ fontSize: 14, color: "#555", textTransform: "uppercase", letterSpacing: 1.4 }}>
+            Opponent's correct guesses
+          </div>
+          <div style={{ fontSize: 28, fontWeight: 700, color: "#c53030" }}>
+            {opponentGuessedCount}/{defendTotal}
+          </div>
+        </div>
+      </div>
+      <div style={{ display: "flex", justifyContent: "center", gap: 16, marginBottom: 24 }}>
+        <details style={{ textAlign: "left", minWidth: 220 }}>
+          <summary style={{ cursor: "pointer", fontWeight: 600 }}>
+            Your wrong guesses ({myWrongGuesses.length})
+          </summary>
+          {myWrongGuesses.length ? (
+            <ul style={{ marginTop: 8 }}>
+              {myWrongGuesses.map((guess, idx) => (
+                <li key={`${guess}-${idx}`}>{guess}</li>
+              ))}
+            </ul>
+          ) : (
+            <p style={{ marginTop: 8, color: "#666" }}>No misses yet.</p>
+          )}
+        </details>
+        <details style={{ textAlign: "left", minWidth: 220 }}>
+          <summary style={{ cursor: "pointer", fontWeight: 600 }}>
+            Opponent's wrong guesses ({opponentWrongGuesses.length})
+          </summary>
+          {opponentWrongGuesses.length ? (
+            <ul style={{ marginTop: 8 }}>
+              {opponentWrongGuesses.map((guess, idx) => (
+                <li key={`${guess}-${idx}`}>{guess}</li>
+              ))}
+            </ul>
+          ) : (
+            <p style={{ marginTop: 8, color: "#666" }}>No misses yet.</p>
+          )}
+        </details>
+      </div>
+
+      <div
+        style={{
+          minHeight: 200,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          marginBottom: 24,
+        }}
+      >
+        {celebratory ? (
+          <div style={{ fontSize: 96, color: "#38a169" }}>✓</div>
+        ) : currentWord ? (
+          <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+            <div style={{ fontSize: 18, color: "#555" }}>Current word</div>
+            <div style={{ display: "flex", gap: 12, justifyContent: "center", flexWrap: "wrap" }}>
+              <div style={boxStyle}>{firstLetter.toUpperCase()}</div>
+              {letters.map((letter, idx) => (
+                <input
+                  key={idx}
+                  ref={(el) => {
+                    inputsRef.current[idx] = el;
+                  }}
+                  type="text"
+                  inputMode="text"
+                  maxLength={1}
+                  value={letter}
+                  onChange={(event) => handleLetterChange(idx, event.target.value)}
+                  onKeyDown={(event) => handleKeyDown(idx, event)}
+                  disabled={!state.isMyTurn}
+                  style={inputStyle}
+                />
+              ))}
+            </div>
+            <button type="submit" disabled={!canSubmit} style={{ padding: "12px 24px", fontSize: 16 }}>
+              Submit guess
+            </button>
+          </form>
+        ) : (
+          <div style={{ fontSize: 20, color: "#555" }}>All opponent words have been revealed!</div>
+        )}
+      </div>
+
+      {error && <div style={{ color: "#c53030", marginBottom: 16 }}>{error}</div>}
+      {!state.isMyTurn && !celebratory && (
+        <div style={{ color: "#666" }}>Waiting for opponent's turn...</div>
+      )}
     </div>
-    <div style={{ margin: 16 }}>
-      <b>Opponent's words left:</b> {
-        state.opponentWordsLeft.map((w, idx) => {
-          if (w.revealed) return <span key={idx}>{w.word}</span>;
-          if (w.word.length === 0) return <span key={idx}></span>;
-          return (
-            <span key={idx} style={{ letterSpacing: "0.4em", display: "inline-block" }}>
-              {w.word[0] + w.word.slice(1).replace(/./g, "_")}
-            </span>
-          );
-        }).reduce<React.ReactNode[]>((acc, el, idx) => {
-          if (idx > 0) acc.push(", ");
-          acc.push(el);
-          return acc;
-        }, [])
-      }
-    </div>
-    <form onSubmit={e => { e.preventDefault(); onGuess(guessValue); }}>
-      <input
-        value={guessValue}
-        onChange={e => setGuessValue(e.target.value)}
-        placeholder="Guess a word"
-        style={{ marginRight: 8 }}
-        disabled={!state.isMyTurn}
-      />
-      <button type="submit" disabled={!state.isMyTurn || !guessValue}>Guess</button>
-    </form>
-    {error && <div style={{ color: "red", marginTop: 8 }}>{error}</div>}
-    {celebratory && <div style={{ color: "green", marginTop: 8 }}>🎉 Correct!</div>}
-    {!state.isMyTurn && <div style={{ marginTop: 16, color: "#888" }}>Waiting for opponent's turn...</div>}
-  </div>
-);
+  );
+};
 
 export default GameBoard;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -19,6 +19,11 @@ export interface GuessResult {
   playerId: string;
 }
 
+export interface WrongGuess {
+  playerId: string;
+  guess: string;
+}
+
 export interface StartGameData {
   players: Player[];
   firstTurn: string;
@@ -42,7 +47,7 @@ export interface RoomStatePayload {
   currentTurn: string;
   playerWords: Record<string, string[]>;
   revealedWords: Record<string, number[]>;
-  wrongGuesses: string[];
+  wrongGuesses: WrongGuess[];
   winner: string | null;
   finalWords: { id: string; words: string[] }[];
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -23,7 +23,7 @@ const playerWords: Record<string, Record<string, string[]>> = {};
 const confirmedPlayers: Record<string, Set<string>> = {};
 // Track revealed words and wrong guesses per room
 const revealedWords: Record<string, Record<string, number[]>> = {};
-const wrongGuesses: Record<string, string[]> = {};
+const wrongGuesses: Record<string, { playerId: string; guess: string }[]> = {};
 const currentTurn: Record<string, string> = {};
 const gameStatus: Record<
   string,
@@ -232,7 +232,7 @@ io.on("connection", (socket) => {
         // Player continues turn
         nextTurn = playerId;
       } else {
-        wrongGuesses[roomCode].push(guess);
+        wrongGuesses[roomCode].push({ guess, playerId });
         // Switch turn
         nextTurn = opponentId;
       }


### PR DESCRIPTION
## Summary
- redesign the game board to focus on the current word with segmented letter inputs, automatic focus handling, a celebratory check mark, score headers, and expandable wrong-guess lists
- capture separate guess statistics and wrong guesses per player in the socket hook and backend so the UI can display accurate counts
- update the app wiring to consume the new state, trigger celebration timing, and pass the enhanced data to the redesigned board

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7bdc42fe0832cbbde48b0a2ea0048