### PR TITLE
Add waiting message after word submission

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,7 @@ function App() {
   const {
     socket,
     players,
+    confirmedPlayers,
     gameStarted,
     opponentWords,
     currentTurn,
@@ -131,6 +132,24 @@ function App() {
         />
         <WordInput onSubmit={handleConfirmWords} loading={confirmed} />
       </>
+    );
+  }
+  if (!gameStarted && confirmed) {
+    const totalPlayers = players.length;
+    const confirmedCount = Math.min(confirmedPlayers.length, totalPlayers || confirmedPlayers.length);
+    const waitingMessage = totalPlayers > 1
+      ? `Waiting for other players to submit their words (${confirmedCount}/${totalPlayers})...`
+      : "Waiting for another player to join...";
+    return (
+      <Lobby
+        room={room}
+        players={players}
+        shareUrl={shareUrl}
+        onShare={handleShare}
+        onStart={() => {}}
+        isHost={players[0]?.id === (socket.id ?? "")}
+        statusMessage={waitingMessage}
+      />
     );
   }
   if (gameStarted) {

--- a/client/src/components/Lobby.tsx
+++ b/client/src/components/Lobby.tsx
@@ -10,9 +10,18 @@ interface LobbyProps {
   onShare: () => void;
   onStart: () => void;
   isHost: boolean;
+  statusMessage?: string;
 }
 
-const Lobby: React.FC<LobbyProps> = ({ room, players, shareUrl, onShare, onStart, isHost }) => (
+const Lobby: React.FC<LobbyProps> = ({
+  room,
+  players,
+  shareUrl,
+  onShare,
+  onStart,
+  isHost,
+  statusMessage,
+}) => (
   <div style={{ padding: 32, maxWidth: 500, margin: "auto", textAlign: "center" }}>
     <h2>Lobby: {room}</h2>
     <ShareRoom room={room} shareUrl={shareUrl} onShare={onShare} />
@@ -22,7 +31,7 @@ const Lobby: React.FC<LobbyProps> = ({ room, players, shareUrl, onShare, onStart
       <button onClick={onStart} style={{ marginTop: 24 }}>Start Game</button>
     )}
     <div style={{ marginTop: 16, fontSize: 12, color: "#888" }}>
-      Waiting for players to join...
+      {statusMessage ?? "Waiting for players to join..."}
     </div>
   </div>
 );


### PR DESCRIPTION
## Summary
- display lobby status while a player waits for others to submit words instead of returning a blank screen
- allow the lobby to show custom status text so we can explain what the player is waiting on

## Testing
- npm run lint (client)


------
https://chatgpt.com/codex/tasks/task_e_68d7e3a0d394832cb4215c4834d15bee