### PR TITLE
Fix duplicate players on reconnect by introducing stable player identities

### DIFF
--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,8 +1,9 @@
 export interface Player {
   id: string;
   name: string;
+  socketId: string;
+  connected: boolean;
   words?: string[];
-  connected?: boolean;
 }
 
 export interface GameEndData {

--- a/server/src/state.ts
+++ b/server/src/state.ts
@@ -8,6 +8,10 @@ export const wrongGuesses: Record<string, { playerId: string; guess: string }[]>
 export const currentTurn: Record<string, string> = {};
 export const gameStatus: Record<string, RoomStatus> = {};
 export const disconnectedPlayers: Record<string, Record<string, DisconnectedPlayerSnapshot>> = {};
+export const socketToPlayer: Record<
+  string,
+  { roomCode: string; playerId: string }
+> = {};
 
 export const ensureRoomState = (roomCode: string) => {
   if (!rooms[roomCode]) rooms[roomCode] = [];

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,4 +1,9 @@
-export type Player = { id: string; name: string; connected: boolean };
+export type Player = {
+  id: string;
+  name: string;
+  connected: boolean;
+  socketId: string;
+};
 
 export type Room = Record<string, Player[]>;
 
@@ -9,6 +14,7 @@ export type RoomStatus = {
 };
 
 export type DisconnectedPlayerSnapshot = {
+  playerId: string;
   name: string;
   words: string[];
   confirmed: boolean;


### PR DESCRIPTION
## Summary
- persist a stable player identifier in the client session so reconnecting sockets automatically reuse their existing game slot
- track server-side room state by player identifier, reviving disconnected players while still enforcing a two-player limit
- broadcast player identities and connection metadata so the UI can derive host/turn logic without relying on transient socket ids

## Testing
- npm run lint (client)
- npm run build (server)


------
https://chatgpt.com/codex/tasks/task_e_68d7ea2b8a78832c910b8e84746c13a1