### PR TITLE
Clear turn timer when room becomes inactive

### DIFF
--- a/server/src/handlers/disconnect.ts
+++ b/server/src/handlers/disconnect.ts
@@ -1,7 +1,9 @@
 import { Server, Socket } from "socket.io";
 
 import {
+  clearTurnTimer,
   confirmedPlayers,
+  currentTurn,
   disconnectedPlayers,
   playerWords,
   revealedWords,
@@ -48,6 +50,13 @@ export const createDisconnectHandler = (io: Server, socket: Socket) => () => {
   };
 
   rooms[roomCode][playerIndex] = { ...player, connected: false };
+
+  const anyPlayersStillConnected = rooms[roomCode].some((roomPlayer) => roomPlayer.connected);
+
+  if (!anyPlayersStillConnected || currentTurn[roomCode] === playerId) {
+    clearTurnTimer(roomCode);
+  }
+
   io.to(roomCode).emit("players_updated", rooms[roomCode]);
   emitRoomState(io, roomCode);
 


### PR DESCRIPTION
## Summary
- clear the room turn timer when the active or final connected player disconnects
- keep room state emissions in sync by ensuring deadlines reset when the timer stops

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68db02a6fd90832c8cedf7b98a9e9f7d